### PR TITLE
Added port to host field, and updated go requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Because I wanted a project to help me learn Golang.
 
 1. Download the [applicable 64-bit knary binary](https://github.com/sudosammy/knary/releases) __OR__ build knary from source:
 
-__Prerequisite:__ You need Go >=1.7 to build knary yourself. Ideally, use Go 1.10.x.
+__Prerequisite:__ You need Go >=1.9 to build knary yourself. Ideally, use Go 1.10.x.
 ```
 go get -u github.com/sudosammy/knary
 go build knary.go

--- a/knary.go
+++ b/knary.go
@@ -309,8 +309,12 @@ func handleRequest(conn net.Conn) {
 	response := string(buf[:recBytes])
 	headers := strings.Split(response, "\n")
 
+	localPort := conn.LocalAddr().(*net.TCPAddr).Port
+
 	if os.Getenv("DEBUG") == "true" {
-		printy(conn.RemoteAddr().String(), 3)
+		printy("raddr " + conn.RemoteAddr().String(), 3)
+		printy("laddr " + conn.LocalAddr().String(), 3)
+
 		printy(response, 3)
 	}
 
@@ -324,7 +328,7 @@ func handleRequest(conn net.Conn) {
 
 			for _, header := range headers {
 				if stringContains(header, "Host") {
-					host = header
+					host = strings.TrimRight(header, "\r\n") + ":" + strconv.Itoa(localPort)
 				}
 				if stringContains(header, "OPTIONS") ||
 					stringContains(header, "GET") ||


### PR DESCRIPTION
Added port to host field, so that the output shows "Host: knary.domain.net:80" (or 443)

base32.NoEncoding, used by miekg/dns, was not added until 1.9.
https://go.googlesource.com/go/+/5f4f7519b6c038ab6771e6c7111bcd29967f2750

knary wouldn't build for me under 1.7. Updated to >=1.9 and it built fine.