### PR TITLE
Added more webhook support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ knary is a canary token server that notifies a Slack channel when incoming HTTP(
 
 Redteamers use canaries to be notified when someone (or *something*) attempts to interact with a server they control. Canaries help provide visibility over processes that were previously unknown. They can help find areas to probe for RFI or SSRF vulnerabilities, disclose previously unknown servers, provide evidence of a MitM device, or just announce someone interacting with your server.
 
-Defenders also use canaries as tripwires that can alert them of an attacker within their network by having the attacker announce themselves. https://canarytokens.org offers a number of additional ways for defenders to use canaries.
+Defenders also use canaries as tripwires that can alert them of an attacker within their network by having the attacker announce themselves. [https://canarytokens.org](https://canarytokens.org) offers a number of additional ways for defenders to use canaries.
 
 ### Why actually?
 
@@ -21,16 +21,18 @@ Because I wanted a project to help me learn Golang.
 1. Download the [applicable 64-bit knary binary](https://github.com/sudosammy/knary/releases) __OR__ build knary from source:
 
 __Prerequisite:__ You need Go >=1.9 to build knary yourself. Ideally, use Go 1.10.x.
-```
+
+```text
 go get -u github.com/sudosammy/knary
 ```
-2. Create an `A` record matching a subdomain wildcard (`*.mycanary.com`) to your server's IP address
-3. Create an `NS` record matching `dns.mycanary.com` with `ns.mycanary.com` - knary will receive all DNS requests for `*.dns.mycanary.com` 
-4. You can self-sign the certificate for accepting TLS connections with something like `openssl req -x509 -newkey rsa:4096 -keyout server.key -out server.crt -days 365 -nodes`. However, some hosts might refuse to connect - so better you letsencrypt yourself a wildcard cert with something like `sudo certbot certonly --server https://acme-v02.api.letsencrypt.org/directory --manual --preferred-challenges dns -d *.mycanary.com`
-5. Setup your [slack webhook](https://slack.com/apps/A0F7XDUAZ-incoming-webhooks)
-6. Create a `.env` file in the same directory as the binary and [configure](https://github.com/sudosammy/knary#config-options) it as necessary:
 
-```
+1. Create an `A` record matching a subdomain wildcard (`*.mycanary.com`) to your server's IP address
+2. Create an `NS` record matching `dns.mycanary.com` with `ns.mycanary.com` - knary will receive all DNS requests for `*.dns.mycanary.com` 
+3. You can self-sign the certificate for accepting TLS connections with something like `openssl req -x509 -newkey rsa:4096 -keyout server.key -out server.crt -days 365 -nodes`. However, some hosts might refuse to connect - so better you letsencrypt yourself a wildcard cert with something like `sudo certbot certonly --server https://acme-v02.api.letsencrypt.org/directory --manual --preferred-challenges dns -d *.mycanary.com`
+4. Setup your [slack webhook](https://slack.com/apps/A0F7XDUAZ-incoming-webhooks)
+5. Create a `.env` file in the same directory as the binary and [configure](https://github.com/sudosammy/knary#config-options) it as necessary:
+
+```env
 DNS=true
 HTTP=true
 BIND_ADDR=0.0.0.0
@@ -44,23 +46,29 @@ BLACKLIST_FILE=blacklist.txt
 
 SLACK_WEBHOOK=https://hooks.slack.com/services/...
 ```
-7. Run the binary (probably in `screen`, `tmux`, or similar because knary can't daemon _yet_) and hope for output that looks something like this: 
+
+6. Run the binary (probably in `screen`, `tmux`, or similar because knary can't daemon _yet_) and hope for output that looks something like this:
 
 ![knary go-ing](https://github.com/sudosammy/knary/raw/master/screenshots/run.png "knary go-ing")
 
 ## Testing
+
 * HTTP(S) - `curl http://test.mycanary.com` & `curl https://test.mycanary.com`
 * DNS - `dig test.dns.mycanary.com`
 
 ## Blacklisting matches
+
 You might find systems that spam your knary even long after an engagement has ended. To stop these from cluttering your Slack channel knary supports a blacklist (location specified in `.env`). Add the offending subdomains separated by a newline:
-```
+
+```text
 www.mycanary.com
 dns.mycanary.com
 ```
+
 This would stop knary from alerting on `www.mycanary.com` but not `another.www.mycanary.com`. Changes to this file will come into effect immediately without requiring a knary restart.
 
 ## Config Options
+
 * `DNS` Enable/Disable the DNS canary
 * `HTTP` Enable/Disable the HTTP(S) canary
 * `BIND_ADDR` The IP address you want knary to listen on. Example input: `0.0.0.0` to bind to all addresses available
@@ -68,6 +76,9 @@ This would stop knary from alerting on `www.mycanary.com` but not `another.www.m
 * `TLS_*` The location of your certificate and private key necessary for accepting TLS (https) requests
 * `DEBUG` Enable/Disable displaying incoming requests in the terminal and some additional info
 * `SLACK_WEBHOOK` The full URL of the [incoming webhook](https://api.slack.com/custom-integrations/incoming-webhooks) for the Slack channel you want knary to notify
+* `PUSHOVER_TOKEN` The application token for the Pushover Application you want knary to notify
+* `PUSHOVER_USER` The user token of the Pushover User you want knary to nofify.
+* `DISCORD_WEBHOOK` The full URL of the [discord webhook](https://discordapp.com/developers/docs/resources/webhook) for the Discord Channel you want knary to notify
 * `EXT_IP` __Optional__ The IP address the DNS canary will answer `A` questions with. By default knary will use the answer to `knary.{CANARY_DOMAIN}.`. Setting this option will overrule that behaviour
 * `DNS_SERVER` __Optional__ The DNS server to use when asking `dns.{CANARY_DOMAIN}.`. This option is obsolete if `EXT_IP` is set. Default is Google's nameserver: `8.8.8.8`
 * `LOG_FILE` __Optional__ Location for a file that knary will log timestamped matches and some errors. Example input: `/home/me/knary.log`

--- a/libknary/http.go
+++ b/libknary/http.go
@@ -11,8 +11,8 @@ import (
 	"time"
 )
 
+// PrepareRequest starts listening on ports
 func PrepareRequest() (net.Listener, net.Listener) {
-	// start listening on ports
 	ln80, err := net.Listen("tcp", os.Getenv("BIND_ADDR")+":80")
 
 	if err != nil {
@@ -39,6 +39,7 @@ func PrepareRequest() (net.Listener, net.Listener) {
 	return ln80, ln443 // return listeners
 }
 
+// AcceptRequest accepts requests for all http requests
 func AcceptRequest(ln net.Listener, wg *sync.WaitGroup) {
 	for {
 		conn, err := ln.Accept() // accept connections forever
@@ -49,7 +50,6 @@ func AcceptRequest(ln net.Listener, wg *sync.WaitGroup) {
 
 		go handleRequest(conn)
 	}
-	wg.Done()
 }
 
 func handleRequest(conn net.Conn) {

--- a/libknary/interface.go
+++ b/libknary/interface.go
@@ -6,8 +6,8 @@ import (
 	"github.com/fatih/color"
 )
 
+// GiveHead makes pretty [+] things
 func GiveHead(colour int) {
-	// make pretty [+] things
 	green := color.New(color.FgGreen)
 	red := color.New(color.FgRed)
 	blue := color.New(color.FgBlue)
@@ -33,6 +33,7 @@ func GiveHead(colour int) {
 	}
 }
 
+// Printy makes things print cool
 func Printy(msg string, col int) {
 	GiveHead(col)
 	fmt.Println(msg)

--- a/libknary/util.go
+++ b/libknary/util.go
@@ -16,6 +16,7 @@ func stringContains(stringA string, stringB string) bool {
 	)
 }
 
+// CheckUpdate checks for a version update and informs the user if there is a new version update
 func CheckUpdate(version string, githubVersion string, githubURL string) bool {
 	running, err := semver.Make(version)
 

--- a/libknary/webhooks.go
+++ b/libknary/webhooks.go
@@ -16,5 +16,23 @@ func sendMsg(msg string) {
 		}
 	}
 
+	if os.Getenv("PUSHOVER_TOKEN") != "" {
+		jsonMsg := []byte(`{"token":"` + os.Getenv("PUSHOVER_TOKEN") + `","user":"` + os.Getenv("PUSHOVER_USER") + `","message":"` + msg + `"}`)
+		_, err := http.Post("https://api.pushover.net/1/messages.json/", "application/json", bytes.NewBuffer(jsonMsg))
+
+		if err != nil {
+			Printy(err.Error(), 2)
+		}
+	}
+
+	if os.Getenv("DISCORD_WEBHOOK") != "" {
+		jsonMsg := []byte(`{"username":"knary","content":"` + msg + `"}`)
+		_, err := http.Post(os.Getenv("DISCORD_WEBHOOK"), "application/json", bytes.NewBuffer(jsonMsg))
+
+		if err != nil {
+			Printy(err.Error(), 2)
+		}
+	}
+
 	// should be simple enough to add support for other webhooks here
 }

--- a/main.go
+++ b/main.go
@@ -11,8 +11,8 @@ import (
 	"sync"
 	"time"
 
-	"./libknary"
-	//"github.com/sudosammy/knary/libknary"
+	//"./libknary"
+	"github.com/sudosammy/knary/libknary"
 )
 
 const (


### PR DESCRIPTION
In this branched version
- Added support for more webhooks, introducing Pushover and Discord.
- Updated readme.md to fit best practices for markdown and added new documentation on webhooks.
- Added comments for all functions
- Changed the "EXT-IP" to CamelCase "ExtIP" throughout dns.go and main.go
- Removed wg.done from http.go (unreachable code)