### PR TITLE
add collaborator compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,8 @@ This would stop knary from alerting on `www.mycanary.com` but not `another.www.m
 * `LOG_FILE` __Optional__ Location for a file that knary will log timestamped matches and some errors. Example input: `/home/me/knary.log`
 * `BLACKLIST_FILE` __Optional__ Location for a file containing subdomains (separated by newlines) that should be ignored by knary and not logged or posted to Slack. Example input: `blacklist.txt` 
 * `TIMEOUT` __Optional__ The timeout for reading the HTTP(S) request. Default is 2 seconds. Example input: `1`
+* `BURP` Enable Burp Collaborator friendly mode
+* `BURP_COLLAB` Domain to mark as 'collab bro' (eg `burp.{CANARY_DOMAIN}`). This needs to be an NS record set in domain things much like `dns.{CANARY_DOMAIN}`.
+* `BURP_DNS` Local burp collaborator DNS port. This can't be 53, because knary listens on 53. Change collaborator config to be something like 8053, and set this to `127.0.0.1:8053`
+* `BURP_HTTP` Much like the above - set to `127.0.0.1:8080` (or whatever you set the burp HTTP port to be)
+* `BURP_HTTPS` Much like the above - set to `127.0.0.1:8443` (or whatever you set the burp HTTPS port to be)

--- a/libknary/http.go
+++ b/libknary/http.go
@@ -147,7 +147,17 @@ func handleRequest(conn net.Conn) {
 			for _, header := range headers {
 				if stringContains(header, "Host") {
 					host = header
-					host = strings.TrimRight(header, "\r\n") + ":" + strconv.Itoa(lPort)
+					host = strings.TrimRight(header, "\r\n") + ":"
+					//using a reverse proxy, set ports back to the actual received ones
+					if os.Getenv("BURP") == "true" {
+						if lPort == 8880 {
+							host = host + "80"
+						} else if lPort == 8843 {
+							host = host + "443"
+						}
+					} else {
+						host = host + strconv.Itoa(lPort)
+					}
 				}
 				if stringContains(header, "OPTIONS") ||
 					stringContains(header, "GET") ||

--- a/libknary/http.go
+++ b/libknary/http.go
@@ -49,7 +49,7 @@ func PrepareRequest() (net.Listener, net.Listener) {
 			e := http.ListenAndServeTLS(os.Getenv("BIND_ADDR")+":443", os.Getenv("TLS_CRT"), os.Getenv("TLS_KEY"),
 				&httputil.ReverseProxy{Director: func(r *http.Request) {
 					r.URL.Scheme = "https"
-					r.URL.Host = r.Host + strings.Split(os.Getenv("BURP_HTTPS"), ":")[1]
+					r.URL.Host = r.Host + ":" + strings.Split(os.Getenv("BURP_HTTPS"), ":")[1]
 					//if the incoming request has the burp suffix send it to collab
 					if strings.HasSuffix(r.Host, os.Getenv("BURP_COLLAB")) {
 					} else {

--- a/libknary/http.go
+++ b/libknary/http.go
@@ -181,6 +181,8 @@ func handleRequest(conn net.Conn) {
 								srcAndPort = append(srcAndPort, srcaddr)
 							}
 						}
+					} else {
+						srcAndPort = mult
 					}
 					fwd = "X-Forwarded-For: " + strings.Join(srcAndPort, "")
 				}

--- a/main.go
+++ b/main.go
@@ -87,6 +87,9 @@ func main() {
 	if os.Getenv("DNS") == "true" {
 		libknary.Printy("Listening for *.dns."+os.Getenv("CANARY_DOMAIN")+" DNS requests", 1)
 	}
+	if os.Getenv("BURP") == "true" {
+		libknary.Printy("Working in collaborator compatibility mode on domain *."+os.Getenv("BURP_COLLAB"), 1)
+	}
 	libknary.Printy("Posting to webhook: "+os.Getenv("SLACK_WEBHOOK"), 1)
 
 	// setup waitgroups for DNS/HTTP go routines


### PR DESCRIPTION
It now plays nicely with collaborator on the same host by using a reverse proxy to front HTTP/S requests, and just blindly forwarding DNS requests on.




(hack the planet)