### PR TITLE
Allow blocking of user-agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If your registry requires you to have multiple nameservers with **different** IP
 ## Allowing or denying matches
 You **will** find systems that spam your knary even long after an engagement has ended. You will also find several DNS requests to mundane subdomains hitting your knary every day. To stop these from cluttering your notifications knary has a few features:
 
-1. A simple text-based deny and/or allowlist (location specified with `DENYLIST_FILE` and/or `ALLOWLIST_FILE`). Add the subdomains or IP addresses separated by a newline (case-insensitive):
+1. A simple text-based deny and/or allowlist (location specified with `DENYLIST_FILE` and/or `ALLOWLIST_FILE`). Add the subdomains, IP addresses, or User-Agents separated by a newline (case-insensitive):
 ```
 knary.tld
 www.knary.tld

--- a/libknary/http.go
+++ b/libknary/http.go
@@ -233,7 +233,7 @@ func handleRequest(conn net.Conn) bool {
 			}
 
 			// take off the header name for the user agent
-			userAgent = strings.TrimPrefix(userAgent, "User-Agent:")
+			userAgent = strings.TrimPrefix(strings.ToLower(userAgent), "user-agent:")
 			hostDomain := strings.TrimPrefix(strings.ToLower(host), "host:") // trim off the "Host:" section of header
 
 			if inAllowlist(hostDomain, conn.RemoteAddr().String(), fwd) && !inBlacklist(hostDomain, conn.RemoteAddr().String(), fwd) && inAllowlist(userAgent) && !inBlacklist(userAgent) {

--- a/libknary/http.go
+++ b/libknary/http.go
@@ -232,8 +232,11 @@ func handleRequest(conn net.Conn) bool {
 				}
 			}
 
+			// take off the header name for the user agent
+			userAgent = strings.TrimPrefix(userAgent, "User-Agent:")
 			hostDomain := strings.TrimPrefix(strings.ToLower(host), "host:") // trim off the "Host:" section of header
-			if inAllowlist(hostDomain, conn.RemoteAddr().String(), fwd) && !inBlacklist(hostDomain, conn.RemoteAddr().String(), fwd) {
+
+			if inAllowlist(hostDomain, conn.RemoteAddr().String(), fwd) && !inBlacklist(hostDomain, conn.RemoteAddr().String(), fwd) && inAllowlist(userAgent) && !inBlacklist(userAgent) {
 				var msg string
 				var fromIP string
 

--- a/libknary/util.go
+++ b/libknary/util.go
@@ -241,7 +241,7 @@ func HeartBeat(version string, firstrun bool) (bool, error) {
 
 	// print denied items (if any)
 	if denyCount > 0 {
-		beatMsg += strconv.Itoa(denyCount) + " denied subdomains / IPs: \n"
+		beatMsg += strconv.Itoa(denyCount) + " denied subdomains / User-Agents / IPs: \n"
 		beatMsg += "------------------------\n"
 		for subdomain := range denied.deny {
 			beatMsg += subdomain + "\n"


### PR DESCRIPTION
I ant to block user agents because Expanse is spammy.

Tested with the below UAs

```sh
curl $HOST --user-agent "asdklfjhasdf asjkdlfh askdjlf haskdjfahsdfkljhasdf "
curl $HOST --user-agent "asdklfjhasdf "
curl $HOST --user-agent ".a.s.d.k.l.f.j.h.a.s.d.f."
curl $HOST --user-agent ".a.s.d.k.l.f.j.h.a.s.d.f. "
curl $HOST --user-agent ".a.s.d.: : : : : : : : : : : : : : : : :k.l.f.j.h.a.s.d.f. "
curl $HOST --user-agent "asdklfjhasdf asjkdlfh askdjlf haskdjfahsdfkljhasdf "
curl $HOST --user-agent "asdklfjhasdf "
curl $HOST --user-agent ".a.s.d.k.l.f.j.h.a.s.d.f."
curl $HOST --user-agent ".a.s.d.k.l.f.j.h.a.s.d.f. "
curl $HOST --user-agent ".a.s.d.: : : : : : : : : : : : : : : : :k.l.f.j.h.a.s.d.f. "
curl $HOST --user-agent "a/b/c/d/e/f/g"
```

A request with an empty UA (`curl $HOST --user-agent ""`) goes through just fine.